### PR TITLE
Remove task to add taint to control plane nodes in CSI install

### DIFF
--- a/tasks/bootstrap_deploy.yml
+++ b/tasks/bootstrap_deploy.yml
@@ -73,12 +73,6 @@
 
 # Deploy vSphere Container Storage Plug-in (CSI)
 #---------------------------------------------------------
-- name: "CSI - Taint all control plane nodes on cluster: {{ item.item }}"
-  shell: |
-    kubectl taint nodes -l node-role.kubernetes.io/controlplane=true node-role.kubernetes.io/control-plane=:NoSchedule --overwrite
-  environment:
-    KUBECONFIG: "{{ kubeconfig_dir }}/kubeconfig_{{ item.item }}"
-
 - name: "CSI - Get number of control plane nodes in cluster on cluster: {{ item.item }}"
   shell: |
     kubectl get nodes -l node-role.kubernetes.io/controlplane=true -o name | wc -l


### PR DESCRIPTION
The task to add a taint to all control plane nodes in a cluster is extraneous because when a new cluster is provisioned, it already contains the taint: 

```
node-role.kubernetes.io/controlplane=true:NoSchedule
```

As along as we use the Rancher-specific vSphere Container Storage Plug-in helm charts, this taint is in the toleration list and therefore we don't need to add the taint documented in the upstream vsphere CSI install process (which uses `control-plane` in the taint name). 